### PR TITLE
cleanup some warnings

### DIFF
--- a/Clipper/src/de/lighti/clipper/Clipper.java
+++ b/Clipper/src/de/lighti/clipper/Clipper.java
@@ -3,52 +3,52 @@ package de.lighti.clipper;
 import de.lighti.clipper.Point.LongPoint;
 
 public interface Clipper {
-    public enum ClipType {
+    enum ClipType {
         INTERSECTION, UNION, DIFFERENCE, XOR
     }
 
     enum Direction {
         RIGHT_TO_LEFT, LEFT_TO_RIGHT
-    };
+    }
 
-    public enum EndType {
+    enum EndType {
         CLOSED_POLYGON, CLOSED_LINE, OPEN_BUTT, OPEN_SQUARE, OPEN_ROUND
-    };
+    }
 
-    public enum JoinType {
+    enum JoinType {
         SQUARE, ROUND, MITER
-    };
+    }
 
-    public enum PolyFillType {
+    enum PolyFillType {
         EVEN_ODD, NON_ZERO, POSITIVE, NEGATIVE
-    };
+    }
 
-    public enum PolyType {
+    enum PolyType {
         SUBJECT, CLIP
-    };
+    }
 
-    public interface ZFillCallback {
-        void zFill( LongPoint bot1, LongPoint top1, LongPoint bot2, LongPoint top2, LongPoint pt );
-    };
+    interface ZFillCallback {
+        void zFill(LongPoint bot1, LongPoint top1, LongPoint bot2, LongPoint top2, LongPoint pt);
+    }
 
     //InitOptions that can be passed to the constructor ...
-    public final static int REVERSE_SOLUTION = 1;
+    int REVERSE_SOLUTION = 1;
 
-    public final static int STRICTLY_SIMPLE = 2;
+    int STRICTLY_SIMPLE = 2;
 
-    public final static int PRESERVE_COLINEAR = 4;
+    int PRESERVE_COLINEAR = 4;
 
-    boolean addPath( Path pg, PolyType polyType, boolean Closed );
+    boolean addPath(Path pg, PolyType polyType, boolean Closed);
 
-    boolean addPaths( Paths ppg, PolyType polyType, boolean closed );
+    boolean addPaths(Paths ppg, PolyType polyType, boolean closed);
 
     void clear();
 
-    boolean execute( ClipType clipType, Paths solution );
+    boolean execute(ClipType clipType, Paths solution);
 
-    boolean execute( ClipType clipType, Paths solution, PolyFillType subjFillType, PolyFillType clipFillType );
+    boolean execute(ClipType clipType, Paths solution, PolyFillType subjFillType, PolyFillType clipFillType);
 
-    boolean execute( ClipType clipType, PolyTree polytree );
+    boolean execute(ClipType clipType, PolyTree polytree);
 
-    public boolean execute( ClipType clipType, PolyTree polytree, PolyFillType subjFillType, PolyFillType clipFillType );
+    boolean execute(ClipType clipType, PolyTree polytree, PolyFillType subjFillType, PolyFillType clipFillType);
 }

--- a/Clipper/src/de/lighti/clipper/ClipperBase.java
+++ b/Clipper/src/de/lighti/clipper/ClipperBase.java
@@ -1,11 +1,11 @@
 package de.lighti.clipper;
 
+import de.lighti.clipper.Path.OutRec;
+import de.lighti.clipper.Point.LongPoint;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
-
-import de.lighti.clipper.Path.OutRec;
-import de.lighti.clipper.Point.LongPoint;
 
 public abstract class ClipperBase implements Clipper {
     protected class LocalMinima {
@@ -26,14 +26,14 @@ public abstract class ClipperBase implements Clipper {
         Maxima prev;
     }
 
-    private static void initEdge( Edge e, Edge eNext, Edge ePrev, LongPoint pt ) {
+    private static void initEdge(Edge e, Edge eNext, Edge ePrev, LongPoint pt ) {
         e.next = eNext;
         e.prev = ePrev;
         e.setCurrent( new LongPoint( pt ) );
         e.outIdx = Edge.UNASSIGNED;
     }
 
-    private static void initEdge2( Edge e, PolyType polyType ) {
+    private static void initEdge2(Edge e, PolyType polyType ) {
         if (e.getCurrent().getY() >= e.next.getCurrent().getY()) {
             e.setBot( new LongPoint( e.getCurrent() ) );
             e.setTop( new LongPoint( e.next.getCurrent() ) );
@@ -55,7 +55,7 @@ public abstract class ClipperBase implements Clipper {
         }
     }
 
-    private static Edge removeEdge( Edge e ) {
+    private static Edge removeEdge(Edge e ) {
         //removes e from double_linked_list (but without removing from memory)
         e.prev.next = e.next;
         e.next.prev = e.prev;
@@ -72,11 +72,9 @@ public abstract class ClipperBase implements Clipper {
 
     protected LocalMinima currentLM;
 
-    private final List<List<Edge>> edges = new ArrayList<List<Edge>>();
-
     protected Scanbeam scanbeam;
 
-    protected final List<OutRec> polyOuts = new ArrayList<OutRec>();
+    protected final List<OutRec> polyOuts = new ArrayList<>();
 
     protected Edge activeEdges;
 
@@ -95,7 +93,7 @@ public abstract class ClipperBase implements Clipper {
     }
 
     @Override
-    public boolean addPath( Path pg, PolyType polyType, boolean Closed ) {
+    public boolean addPath(Path pg, PolyType polyType, boolean Closed ) {
 
         if (!Closed && polyType == PolyType.CLIP) {
             throw new IllegalStateException( "AddPath: Open paths must be subject." );
@@ -115,7 +113,7 @@ public abstract class ClipperBase implements Clipper {
         }
 
         //create a new edge array ...
-        final List<Edge> edges = new ArrayList<Edge>( highI + 1 );
+        final List<Edge> edges = new ArrayList<>( highI + 1 );
         for (int i = 0; i <= highI; i++) {
             edges.add( new Edge() );
         }
@@ -217,11 +215,9 @@ public abstract class ClipperBase implements Clipper {
                 e = e.next;
             }
             insertLocalMinima( locMin );
-            this.edges.add( edges );
             return true;
         }
 
-        this.edges.add( edges );
         boolean leftBoundIsForward;
         Edge EMin = null;
 
@@ -295,10 +291,10 @@ public abstract class ClipperBase implements Clipper {
     }
 
     @Override
-    public boolean addPaths( Paths ppg, PolyType polyType, boolean closed ) {
+    public boolean addPaths(Paths paths, PolyType polyType, boolean closed ) {
         boolean result = false;
-        for (int i = 0; i < ppg.size(); ++i) {
-            if (addPath( ppg.get( i ), polyType, closed )) {
+        for (Path path : paths) {
+            if (addPath(path, polyType, closed)) {
                 result = true;
             }
         }
@@ -308,7 +304,6 @@ public abstract class ClipperBase implements Clipper {
     @Override
     public void clear() {
         disposeLocalMinimaList();
-        edges.clear();
         hasOpenPaths = false;
     }
 
@@ -338,8 +333,7 @@ public abstract class ClipperBase implements Clipper {
             tmpLm.next = newLm;
         }
     }
-
-    public boolean isPreserveCollinear() {
+    private boolean isPreserveCollinear() {
         return preserveCollinear;
     }
 
@@ -353,7 +347,7 @@ public abstract class ClipperBase implements Clipper {
         return false;
     }
 
-    private Edge processBound( Edge e, boolean LeftBoundIsForward ) {
+    private Edge processBound(Edge e, boolean LeftBoundIsForward ) {
         Edge EStart, result = e;
         Edge Horz;
 
@@ -605,7 +599,7 @@ public abstract class ClipperBase implements Clipper {
         }
     }
 
-    protected void swapPositionsInAEL( Edge edge1, Edge edge2 ) {
+    protected void swapPositionsInAEL(Edge edge1, Edge edge2 ) {
         LOGGER.entering( ClipperBase.class.getName(), "swapPositionsInAEL" );
 
         //check that one or other edge hasn't already been removed from AEL ...

--- a/Clipper/src/de/lighti/clipper/ClipperOffset.java
+++ b/Clipper/src/de/lighti/clipper/ClipperOffset.java
@@ -1,16 +1,12 @@
 package de.lighti.clipper;
 
+import de.lighti.clipper.Clipper.*;
+import de.lighti.clipper.Point.DoublePoint;
+import de.lighti.clipper.Point.LongPoint;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import de.lighti.clipper.Clipper.ClipType;
-import de.lighti.clipper.Clipper.EndType;
-import de.lighti.clipper.Clipper.JoinType;
-import de.lighti.clipper.Clipper.PolyFillType;
-import de.lighti.clipper.Clipper.PolyType;
-import de.lighti.clipper.Point.DoublePoint;
-import de.lighti.clipper.Point.LongPoint;
 
 public class ClipperOffset {
     private static boolean nearZero( double val ) {
@@ -45,12 +41,12 @@ public class ClipperOffset {
         this.miterLimit = miterLimit;
         this.arcTolerance = arcTolerance;
         lowest = new LongPoint();
-        lowest.setX( -1l );
+        lowest.setX( -1L );
         polyNodes = new PolyNode();
-        normals = new ArrayList<DoublePoint>();
+        normals = new ArrayList<>();
     }
 
-    public void addPath( Path path, JoinType joinType, EndType endType ) {
+    public void addPath(Path path, JoinType joinType, EndType endType ) {
         int highI = path.size() - 1;
         if (highI < 0) {
             return;
@@ -100,7 +96,7 @@ public class ClipperOffset {
         }
     }
 
-    public void addPaths( Paths paths, JoinType joinType, EndType endType ) {
+    public void addPaths(Paths paths, JoinType joinType, EndType endType ) {
         for (final Path p : paths) {
             addPath( p, joinType, endType );
         }
@@ -108,7 +104,7 @@ public class ClipperOffset {
 
     public void clear() {
         polyNodes.getChilds().clear();
-        lowest.setX( -1l );
+        lowest.setX( -1L );
     }
 
     private void doMiter( int j, int k, double r ) {
@@ -333,7 +329,7 @@ public class ClipperOffset {
 
     //------------------------------------------------------------------------------
 
-    public void execute( Paths solution, double delta ) {
+    public void execute(Paths solution, double delta ) {
         solution.clear();
         fixOrientations();
         doOffset( delta );
@@ -363,7 +359,7 @@ public class ClipperOffset {
 
     //------------------------------------------------------------------------------
 
-    public void execute( PolyTree solution, double delta ) {
+    public void execute(PolyTree solution, double delta ) {
         solution.Clear();
         fixOrientations();
         doOffset( delta );

--- a/Clipper/src/de/lighti/clipper/ClipperOffset.java
+++ b/Clipper/src/de/lighti/clipper/ClipperOffset.java
@@ -113,7 +113,7 @@ public class ClipperOffset {
 
     private void doMiter( int j, int k, double r ) {
         final double q = delta / r;
-        destPoly.add( new LongPoint( (int) Math.round( srcPoly.get( j ).getX() + (normals.get( k ).getX() + normals.get( j ).getX()) * q ), (int) Math
+        destPoly.add( new LongPoint( Math.round( srcPoly.get( j ).getX() + (normals.get( k ).getX() + normals.get( j ).getX()) * q ), Math
                         .round( srcPoly.get( j ).getY() + (normals.get( k ).getY() + normals.get( j ).getY()) * q ) ) );
     }
 
@@ -175,7 +175,7 @@ public class ClipperOffset {
                 if (node.getJoinType() == JoinType.ROUND) {
                     double X = 1.0, Y = 0.0;
                     for (int j = 1; j <= steps; j++) {
-                        destPoly.add( new LongPoint( (int) Math.round( srcPoly.get( 0 ).getX() + X * delta ), (int) Math.round( srcPoly.get( 0 ).getY() + Y
+                        destPoly.add( new LongPoint( Math.round( srcPoly.get( 0 ).getX() + X * delta ), Math.round( srcPoly.get( 0 ).getY() + Y
                                         * delta ) ) );
                         final double X2 = X;
                         X = X * cos - sin * Y;
@@ -185,7 +185,7 @@ public class ClipperOffset {
                 else {
                     double X = -1.0, Y = -1.0;
                     for (int j = 0; j < 4; ++j) {
-                        destPoly.add( new LongPoint( (int) Math.round( srcPoly.get( 0 ).getX() + X * delta ), (int) Math.round( srcPoly.get( 0 ).getY() + Y
+                        destPoly.add( new LongPoint( Math.round( srcPoly.get( 0 ).getX() + X * delta ), Math.round( srcPoly.get( 0 ).getY() + Y
                                         * delta ) ) );
                         if (X < 0) {
                             X = 1;
@@ -249,10 +249,10 @@ public class ClipperOffset {
                 LongPoint pt1;
                 if (node.getEndType() == EndType.OPEN_BUTT) {
                     final int j = len - 1;
-                    pt1 = new LongPoint( (int) Math.round( srcPoly.get( j ).getX() + normals.get( j ).getX() * delta ), (int) Math.round( srcPoly.get( j )
+                    pt1 = new LongPoint( Math.round( srcPoly.get( j ).getX() + normals.get( j ).getX() * delta ), Math.round( srcPoly.get( j )
                                     .getY() + normals.get( j ).getY() * delta ), 0 );
                     destPoly.add( pt1 );
-                    pt1 = new LongPoint( (int) Math.round( srcPoly.get( j ).getX() - normals.get( j ).getX() * delta ), (int) Math.round( srcPoly.get( j )
+                    pt1 = new LongPoint( Math.round( srcPoly.get( j ).getX() - normals.get( j ).getX() * delta ), Math.round( srcPoly.get( j )
                                     .getY() - normals.get( j ).getY() * delta ), 0 );
                     destPoly.add( pt1 );
                 }
@@ -282,10 +282,10 @@ public class ClipperOffset {
                 }
 
                 if (node.getEndType() == EndType.OPEN_BUTT) {
-                    pt1 = new LongPoint( (int) Math.round( srcPoly.get( 0 ).getX() - normals.get( 0 ).getX() * delta ), (int) Math.round( srcPoly.get( 0 )
+                    pt1 = new LongPoint( Math.round( srcPoly.get( 0 ).getX() - normals.get( 0 ).getX() * delta ), Math.round( srcPoly.get( 0 )
                                     .getY() - normals.get( 0 ).getY() * delta ) );
                     destPoly.add( pt1 );
-                    pt1 = new LongPoint( (int) Math.round( srcPoly.get( 0 ).getX() + normals.get( 0 ).getX() * delta ), (int) Math.round( srcPoly.get( 0 )
+                    pt1 = new LongPoint( Math.round( srcPoly.get( 0 ).getX() + normals.get( 0 ).getX() * delta ), Math.round( srcPoly.get( 0 )
                                     .getY() + normals.get( 0 ).getY() * delta ) );
                     destPoly.add( pt1 );
                 }
@@ -310,12 +310,12 @@ public class ClipperOffset {
 
         double X = normals.get( k ).getX(), Y = normals.get( k ).getY(), X2;
         for (int i = 0; i < steps; ++i) {
-            destPoly.add( new LongPoint( (int) Math.round( srcPoly.get( j ).getX() + X * delta ), (int) Math.round( srcPoly.get( j ).getY() + Y * delta ) ) );
+            destPoly.add( new LongPoint( Math.round( srcPoly.get( j ).getX() + X * delta ), Math.round( srcPoly.get( j ).getY() + Y * delta ) ) );
             X2 = X;
             X = X * cos - sin * Y;
             Y = X2 * sin + Y * cos;
         }
-        destPoly.add( new LongPoint( (int) Math.round( srcPoly.get( j ).getX() + normals.get( j ).getX() * delta ), (int) Math.round( srcPoly.get( j ).getY()
+        destPoly.add( new LongPoint( Math.round( srcPoly.get( j ).getX() + normals.get( j ).getX() * delta ), Math.round( srcPoly.get( j ).getY()
                         + normals.get( j ).getY() * delta ) ) );
     }
 
@@ -327,8 +327,8 @@ public class ClipperOffset {
         final double sjx = srcPoly.get( j ).getX();
         final double sjy = srcPoly.get( j ).getY();
         final double dx = Math.tan( Math.atan2( inA, nkx * njx + nky * njy ) / 4 );
-        destPoly.add( new LongPoint( (int) Math.round( sjx + delta * (nkx - nky * dx) ), (int) Math.round( sjy + delta * (nky + nkx * dx) ), 0 ) );
-        destPoly.add( new LongPoint( (int) Math.round( sjx + delta * (njx + njy * dx) ), (int) Math.round( sjy + delta * (njy - njx * dx) ), 0 ) );
+        destPoly.add( new LongPoint( Math.round( sjx + delta * (nkx - nky * dx) ), Math.round( sjy + delta * (nky + nkx * dx) ), 0 ) );
+        destPoly.add( new LongPoint( Math.round( sjx + delta * (njx + njy * dx) ), Math.round( sjy + delta * (njy - njx * dx) ), 0 ) );
     }
 
     //------------------------------------------------------------------------------
@@ -442,7 +442,7 @@ public class ClipperOffset {
             final double cosA = nkx * njx + njy * nky;
             if (cosA > 0) // angle ==> 0 degrees
             {
-                destPoly.add( new LongPoint( (int) Math.round( sjx + nkx * delta ), (int) Math.round( sjy + nky * delta ), 0 ) );
+                destPoly.add( new LongPoint( Math.round( sjx + nkx * delta ), Math.round( sjy + nky * delta ), 0 ) );
                 return;
             }
             //else angle ==> 180 degrees
@@ -455,9 +455,9 @@ public class ClipperOffset {
         }
 
         if (inA * delta < 0) {
-            destPoly.add( new LongPoint( (int) Math.round( sjx + nkx * delta ), (int) Math.round( sjy + nky * delta ) ) );
+            destPoly.add( new LongPoint( Math.round( sjx + nkx * delta ), Math.round( sjy + nky * delta ) ) );
             destPoly.add( srcPoly.get( j ) );
-            destPoly.add( new LongPoint( (int) Math.round( sjx + njx * delta ), (int) Math.round( sjy + njy * delta ) ) );
+            destPoly.add( new LongPoint( Math.round( sjx + njx * delta ), Math.round( sjy + njy * delta ) ) );
         }
         else {
             switch (jointype) {

--- a/Clipper/src/de/lighti/clipper/DefaultClipper.java
+++ b/Clipper/src/de/lighti/clipper/DefaultClipper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import de.lighti.clipper.Path.Join;
@@ -707,8 +708,10 @@ public class DefaultClipper extends ClipperBase {
             //OutRec.Pts is the 'Left-most' point & OutRec.Pts.Prev is the 'Right-most'
             final Path.OutPt op = outRec.getPoints();
             final boolean ToFront = e.side == Edge.Side.LEFT;
-            LOGGER.finest( "op=" + Path.OutPt.getPointCount( op ) );
-            LOGGER.finest( ToFront + " " + pt + " " + op.getPt() );
+            if (LOGGER.isLoggable( Level.FINEST )) {
+                LOGGER.finest( "op=" + Path.OutPt.getPointCount( op ) );
+                LOGGER.finest( ToFront + " " + pt + " " + op.getPt() );
+            }
             if (ToFront && pt.equals( op.getPt() )) {
                 return op;
             }

--- a/Clipper/src/de/lighti/clipper/DefaultClipper.java
+++ b/Clipper/src/de/lighti/clipper/DefaultClipper.java
@@ -1,14 +1,14 @@
 package de.lighti.clipper;
 
+import de.lighti.clipper.Path.Join;
+import de.lighti.clipper.Path.OutRec;
+import de.lighti.clipper.Point.LongPoint;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Logger;
-
-import de.lighti.clipper.Path.Join;
-import de.lighti.clipper.Path.OutRec;
-import de.lighti.clipper.Point.LongPoint;
 
 public class DefaultClipper extends ClipperBase {
     private class IntersectNode {
@@ -16,17 +16,17 @@ public class DefaultClipper extends ClipperBase {
         Edge Edge2;
         private LongPoint pt;
 
-        public LongPoint getPt() {
+        LongPoint getPt() {
             return pt;
         }
 
-        public void setPt( LongPoint pt ) {
+        void setPt( LongPoint pt ) {
             this.pt = pt;
         }
 
-    };
+    }
 
-    private static void getHorzDirection( Edge HorzEdge, Direction[] Dir, long[] Left, long[] Right ) {
+    private static void getHorzDirection(Edge HorzEdge, Direction[] Dir, long[] Left, long[] Right ) {
         if (HorzEdge.getBot().getX() < HorzEdge.getTop().getX()) {
             Left[0] = HorzEdge.getBot().getX();
             Right[0] = HorzEdge.getTop().getX();
@@ -63,7 +63,7 @@ public class DefaultClipper extends ClipperBase {
         return Left[0] < Right[0];
     }
 
-    private static boolean isOutRec1RightOfOutRec2( OutRec outRec1, OutRec outRec2 ) {
+    private static boolean isOutRec1RightOfOutRec2(OutRec outRec1, OutRec outRec2 ) {
         do {
             outRec1 = outRec1.firstLeft;
             if (outRec1 == outRec2) {
@@ -76,7 +76,7 @@ public class DefaultClipper extends ClipperBase {
 
     //See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann & Agathos
     //http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.88.5498&rep=rep1&type=pdf
-    private static int isPointInPolygon( LongPoint pt, Path.OutPt op ) {
+    private static int isPointInPolygon(LongPoint pt, Path.OutPt op ) {
         //returns 0 if false, +1 if true, -1 if pt ON polygon boundary
         int result = 0;
         final Path.OutPt startOp = op;
@@ -127,7 +127,7 @@ public class DefaultClipper extends ClipperBase {
     }
 
     //------------------------------------------------------------------------------
-    private static boolean joinHorz( Path.OutPt op1, Path.OutPt op1b, Path.OutPt op2, Path.OutPt op2b, LongPoint Pt, boolean DiscardLeft ) {
+    private static boolean joinHorz(Path.OutPt op1, Path.OutPt op1b, Path.OutPt op2, Path.OutPt op2b, LongPoint Pt, boolean DiscardLeft ) {
         final Direction Dir1 = op1.getPt().getX() > op1b.getPt().getX() ? Direction.RIGHT_TO_LEFT : Direction.LEFT_TO_RIGHT;
         final Direction Dir2 = op2.getPt().getX() > op2b.getPt().getX() ? Direction.RIGHT_TO_LEFT : Direction.LEFT_TO_RIGHT;
         if (Dir1 == Dir2) {
@@ -181,7 +181,6 @@ public class DefaultClipper extends ClipperBase {
                 op2.setPt( new LongPoint( Pt ) );
                 op2b = op2.duplicate( !DiscardLeft );
             }
-            ;
         }
         else {
             while (op2.next.getPt().getX() >= Pt.getX() && op2.next.getPt().getX() <= op2.getPt().getX() && op2.next.getPt().getY() == Pt.getY()) {
@@ -196,9 +195,7 @@ public class DefaultClipper extends ClipperBase {
                 op2.setPt( new LongPoint( Pt ) );
                 op2b = op2.duplicate( DiscardLeft );
             }
-            ;
         }
-        ;
 
         if (Dir1 == Direction.LEFT_TO_RIGHT == DiscardLeft) {
             op1.prev = op2;
@@ -215,7 +212,7 @@ public class DefaultClipper extends ClipperBase {
         return true;
     }
 
-    private static boolean joinPoints( Join j, OutRec outRec1, OutRec outRec2 ) {
+    private static boolean joinPoints(Join j, OutRec outRec1, OutRec outRec2 ) {
         Path.OutPt op1 = j.outPt1, op1b;
         Path.OutPt op2 = j.outPt2, op2b;
 
@@ -348,7 +345,6 @@ public class DefaultClipper extends ClipperBase {
                     return false;
                 }
             }
-            ;
             op2b = op2.next;
             while (op2b.getPt().equals( op2.getPt() ) && op2b != op2) {
                 op2b = op2b.next;
@@ -393,7 +389,7 @@ public class DefaultClipper extends ClipperBase {
         }
     }
 
-    private static Paths minkowski( Path pattern, Path path, boolean IsSum, boolean IsClosed ) {
+    private static Paths minkowski(Path pattern, Path path, boolean IsSum, boolean IsClosed ) {
         final int delta = IsClosed ? 1 : 0;
         final int polyCnt = pattern.size();
         final int pathCnt = path.size();
@@ -434,7 +430,7 @@ public class DefaultClipper extends ClipperBase {
         return quads;
     }
 
-    public static Paths minkowskiDiff( Path poly1, Path poly2 ) {
+    public static Paths minkowskiDiff(Path poly1, Path poly2 ) {
         final Paths paths = minkowski( poly1, poly2, false, true );
         final DefaultClipper c = new DefaultClipper();
         c.addPaths( paths, PolyType.SUBJECT, true );
@@ -442,7 +438,7 @@ public class DefaultClipper extends ClipperBase {
         return paths;
     }
 
-    public static Paths minkowskiSum( Path pattern, Path path, boolean pathIsClosed ) {
+    public static Paths minkowskiSum(Path pattern, Path path, boolean pathIsClosed ) {
         final Paths paths = minkowski( pattern, path, true, pathIsClosed );
         final DefaultClipper c = new DefaultClipper();
         c.addPaths( paths, PolyType.SUBJECT, true );
@@ -450,7 +446,7 @@ public class DefaultClipper extends ClipperBase {
         return paths;
     }
 
-    public static Paths minkowskiSum( Path pattern, Paths paths, boolean pathIsClosed ) {
+    public static Paths minkowskiSum(Path pattern, Paths paths, boolean pathIsClosed ) {
         final Paths solution = new Paths();
         final DefaultClipper c = new DefaultClipper();
         for (int i = 0; i < paths.size(); ++i) {
@@ -465,7 +461,7 @@ public class DefaultClipper extends ClipperBase {
         return solution;
     }
 
-    private static boolean poly2ContainsPoly1( Path.OutPt outPt1, Path.OutPt outPt2 ) {
+    private static boolean poly2ContainsPoly1(Path.OutPt outPt1, Path.OutPt outPt2 ) {
         Path.OutPt op = outPt1;
         do {
             //nb: PointInPolygon returns 0 if false, +1 if true, -1 if pt on polygon
@@ -483,11 +479,11 @@ public class DefaultClipper extends ClipperBase {
     // SimplifyPolygon functions ...
     // Convert self-intersecting polygons into simple polygons
     //------------------------------------------------------------------------------
-    public static Paths simplifyPolygon( Path poly ) {
+    public static Paths simplifyPolygon(Path poly ) {
         return simplifyPolygon( poly, PolyFillType.EVEN_ODD );
     }
 
-    public static Paths simplifyPolygon( Path poly, PolyFillType fillType ) {
+    public static Paths simplifyPolygon(Path poly, PolyFillType fillType ) {
         final Paths result = new Paths();
         final DefaultClipper c = new DefaultClipper( STRICTLY_SIMPLE );
 
@@ -496,11 +492,11 @@ public class DefaultClipper extends ClipperBase {
         return result;
     }
 
-    public static Paths simplifyPolygons( Paths polys ) {
+    public static Paths simplifyPolygons(Paths polys ) {
         return simplifyPolygons( polys, PolyFillType.EVEN_ODD );
     }
 
-    public static Paths simplifyPolygons( Paths polys, PolyFillType fillType ) {
+    public static Paths simplifyPolygons(Paths polys, PolyFillType fillType ) {
         final Paths result = new Paths();
         final DefaultClipper c = new DefaultClipper( STRICTLY_SIMPLE );
 
@@ -535,7 +531,7 @@ public class DefaultClipper extends ClipperBase {
 
     private boolean usingPolyTree;
 
-    public ZFillCallback zFillFunction;
+    private ZFillCallback zFillFunction;
 
     //------------------------------------------------------------------------------
 
@@ -558,7 +554,7 @@ public class DefaultClipper extends ClipperBase {
         maxima = null;
         activeEdges = null;
         sortedEdges = null;
-        intersectList = new ArrayList<IntersectNode>();
+        intersectList = new ArrayList<>();
         intersectNodeComparer = ( node1, node2 ) -> {
             final long i = node2.getPt().getY() - node1.getPt().getY();
             if (i > 0) {
@@ -573,8 +569,8 @@ public class DefaultClipper extends ClipperBase {
         };
 
         usingPolyTree = false;
-        joins = new ArrayList<Join>();
-        ghostJoins = new ArrayList<Join>();
+        joins = new ArrayList<>();
+        ghostJoins = new ArrayList<>();
         reverseSolution = (REVERSE_SOLUTION & InitOptions) != 0;
         strictlySimple = (STRICTLY_SIMPLE & InitOptions) != 0;
 
@@ -602,7 +598,7 @@ public class DefaultClipper extends ClipperBase {
         }
     }
 
-    private void addGhostJoin( Path.OutPt Op, LongPoint OffPt ) {
+    private void addGhostJoin(Path.OutPt Op, LongPoint OffPt ) {
         final Join j = new Join();
         j.outPt1 = Op;
         j.setOffPt( new LongPoint( OffPt ) );
@@ -611,7 +607,7 @@ public class DefaultClipper extends ClipperBase {
 
     //------------------------------------------------------------------------------
 
-    private void addJoin( Path.OutPt Op1, Path.OutPt Op2, LongPoint OffPt ) {
+    private void addJoin(Path.OutPt Op1, Path.OutPt Op2, LongPoint OffPt ) {
         LOGGER.entering( DefaultClipper.class.getName(), "addJoin" );
         final Join j = new Join();
         j.outPt1 = Op1;
@@ -622,7 +618,7 @@ public class DefaultClipper extends ClipperBase {
 
     //------------------------------------------------------------------------------
 
-    private void addLocalMaxPoly( Edge e1, Edge e2, LongPoint pt ) {
+    private void addLocalMaxPoly(Edge e1, Edge e2, LongPoint pt ) {
         addOutPt( e1, pt );
         if (e2.windDelta == 0) {
             addOutPt( e2, pt );
@@ -641,7 +637,7 @@ public class DefaultClipper extends ClipperBase {
 
     //------------------------------------------------------------------------------
 
-    private Path.OutPt addLocalMinPoly( Edge e1, Edge e2, LongPoint pt ) {
+    private Path.OutPt addLocalMinPoly(Edge e1, Edge e2, LongPoint pt ) {
         LOGGER.entering( DefaultClipper.class.getName(), "addLocalMinPoly" );
         Path.OutPt result;
         Edge e, prevE;
@@ -684,7 +680,7 @@ public class DefaultClipper extends ClipperBase {
         return result;
     }
 
-    private Path.OutPt addOutPt( Edge e, LongPoint pt ) {
+    private Path.OutPt addOutPt(Edge e, LongPoint pt ) {
         LOGGER.entering( DefaultClipper.class.getName(), "addOutPt" );
         if (e.outIdx < 0) {
             final OutRec outRec = createOutRec();
@@ -732,13 +728,13 @@ public class DefaultClipper extends ClipperBase {
 
     private Path.OutPt getLastOutPt(Edge e) {
         OutRec outRec = polyOuts.get( e.outIdx );
-        if (e.side == Edge.Side.LEFT) 
+        if (e.side == Edge.Side.LEFT)
             return outRec.getPoints();
         else
             return outRec.getPoints().prev;
     }
 
-    private void appendPolygon( Edge e1, Edge e2 ) {
+    private void appendPolygon(Edge e1, Edge e2 ) {
         LOGGER.entering( DefaultClipper.class.getName(), "appendPolygon" );
 
         final OutRec outRec1 = polyOuts.get( e1.outIdx );
@@ -1116,17 +1112,17 @@ public class DefaultClipper extends ClipperBase {
     //------------------------------------------------------------------------------
 
     @Override
-    public boolean execute( ClipType clipType, Paths solution ) {
+    public boolean execute(ClipType clipType, Paths solution ) {
         return execute( clipType, solution, PolyFillType.EVEN_ODD, PolyFillType.EVEN_ODD );
     }
 
     @Override
-    public boolean execute( ClipType clipType, PolyTree polytree ) {
+    public boolean execute(ClipType clipType, PolyTree polytree ) {
         return execute( clipType, polytree, PolyFillType.EVEN_ODD, PolyFillType.EVEN_ODD );
     }
 
     @Override
-    public boolean execute( ClipType clipType, Paths solution, PolyFillType subjFillType, PolyFillType clipFillType ) {
+    public boolean execute(ClipType clipType, Paths solution, PolyFillType subjFillType, PolyFillType clipFillType ) {
 
         synchronized (this) {
 
@@ -1157,7 +1153,7 @@ public class DefaultClipper extends ClipperBase {
     }
 
     @Override
-    public boolean execute( ClipType clipType, PolyTree polytree, PolyFillType subjFillType, PolyFillType clipFillType ) {
+    public boolean execute(ClipType clipType, PolyTree polytree, PolyFillType subjFillType, PolyFillType clipFillType ) {
         synchronized (this) {
             this.subjFillType = subjFillType;
             this.clipFillType = clipFillType;
@@ -1238,7 +1234,7 @@ public class DefaultClipper extends ClipperBase {
 
     //------------------------------------------------------------------------------
 
-    private void fixupFirstLefts1( OutRec OldOutRec, OutRec NewOutRec ) {
+    private void fixupFirstLefts1(OutRec OldOutRec, OutRec NewOutRec ) {
         for (OutRec outRec : polyOuts) {
             final OutRec firstLeft = Path.OutRec.parseFirstLeft( outRec.firstLeft );
             if (outRec.getPoints() != null && firstLeft == OldOutRec) {
@@ -1250,7 +1246,7 @@ public class DefaultClipper extends ClipperBase {
     }
     //------------------------------------------------------------------------------
 
-    private void fixupFirstLefts2( OutRec innerOutRec, OutRec outerOutRec ) {
+    private void fixupFirstLefts2(OutRec innerOutRec, OutRec outerOutRec ) {
         //A polygon has split into two such that one is now the inner of the other.
         //It's possible that these polygons now wrap around other polygons, so check
         //every polygon that's also contained by OuterOutRec's FirstLeft container
@@ -1277,7 +1273,7 @@ public class DefaultClipper extends ClipperBase {
     }
     //----------------------------------------------------------------------
 
-    private void fixupFirstLefts3( OutRec oldOutRec, OutRec newOutRec ) {
+    private void fixupFirstLefts3(OutRec oldOutRec, OutRec newOutRec ) {
         //same as FixupFirstLefts1 but doesn't call Poly2ContainsPoly1()
         for (OutRec outRec : polyOuts) {
             final OutRec firstLeft = Path.OutRec.parseFirstLeft( outRec.firstLeft );
@@ -1373,7 +1369,7 @@ public class DefaultClipper extends ClipperBase {
         outRec.setPoints( pp );
     }
 
-    private OutRec getOutRec( int idx ) {
+    private OutRec getOutRec(int idx ) {
         OutRec outrec = polyOuts.get( idx );
         while (outrec != polyOuts.get( outrec.Idx )) {
             outrec = polyOuts.get( outrec.Idx );
@@ -1381,7 +1377,7 @@ public class DefaultClipper extends ClipperBase {
         return outrec;
     }
 
-    private void insertEdgeIntoAEL( Edge edge, Edge startEdge ) {
+    private void insertEdgeIntoAEL(Edge edge, Edge startEdge ) {
         LOGGER.entering( DefaultClipper.class.getName(), "insertEdgeIntoAEL" );
 
         if (activeEdges == null) {
@@ -1511,7 +1507,7 @@ public class DefaultClipper extends ClipperBase {
 
     //------------------------------------------------------------------------------
 
-    private void intersectEdges( Edge e1, Edge e2, LongPoint pt ) {
+    private void intersectEdges(Edge e1, Edge e2, LongPoint pt ) {
         LOGGER.entering( DefaultClipper.class.getName(), "insersectEdges" );
 
         //e1 will be to the left of e2 BELOW the intersection. Therefore e1 is before
@@ -1727,7 +1723,7 @@ public class DefaultClipper extends ClipperBase {
         }
     }
 
-    private void intersectPoint( Edge edge1, Edge edge2, LongPoint[] ipV ) {
+    private void intersectPoint(Edge edge1, Edge edge2, LongPoint[] ipV ) {
         final LongPoint ip = ipV[0] = new LongPoint();
 
         double b1, b2;
@@ -2050,7 +2046,7 @@ public class DefaultClipper extends ClipperBase {
             }
         }
 
-        Path.OutPt op1 = null;
+        Path.OutPt op1;
         for (;;) { //loop through consec. horizontal edges
             final boolean IsLastHorz = horzEdge == eLastHorz;
             Edge e = horzEdge.getNextInAEL( dir[0] );
@@ -2263,7 +2259,7 @@ public class DefaultClipper extends ClipperBase {
         }
     }
 
-    private void setHoleState( Edge e, OutRec outRec ) {
+    private void setHoleState(Edge e, OutRec outRec ) {
         Edge e2 = e.prevInAEL;
         Edge eTmp = null;
         while (e2 != null) {
@@ -2287,7 +2283,7 @@ public class DefaultClipper extends ClipperBase {
         }
     }
 
-    private void setZ( LongPoint pt, Edge e1, Edge e2 ) {
+    private void setZ(LongPoint pt, Edge e1, Edge e2 ) {
         if (pt.getZ() != 0 || zFillFunction == null) {
             return;
         }
@@ -2310,7 +2306,7 @@ public class DefaultClipper extends ClipperBase {
 
     //------------------------------------------------------------------------------;
 
-    private void swapPositionsInSEL( Edge edge1, Edge edge2 ) {
+    private void swapPositionsInSEL(Edge edge1, Edge edge2 ) {
         if (edge1.nextInSEL == null && edge1.prevInSEL == null) {
             return;
         }

--- a/Clipper/src/de/lighti/clipper/Edge.java
+++ b/Clipper/src/de/lighti/clipper/Edge.java
@@ -1,19 +1,19 @@
 package de.lighti.clipper;
 
-import java.util.logging.Logger;
-
 import de.lighti.clipper.Clipper.ClipType;
 import de.lighti.clipper.Clipper.Direction;
 import de.lighti.clipper.Clipper.PolyFillType;
 import de.lighti.clipper.Clipper.PolyType;
 import de.lighti.clipper.Point.LongPoint;
 
+import java.util.logging.Logger;
+
 class Edge {
-    static enum Side {
+    enum Side {
         LEFT, RIGHT
     }
 
-    static boolean doesE2InsertBeforeE1( Edge e1, Edge e2 ) {
+    static boolean doesE2InsertBeforeE1(Edge e1, Edge e2 ) {
         if (e2.current.getX() == e1.current.getX()) {
             if (e2.top.getY() > e1.top.getY()) {
                 return e2.top.getX() < topX( e1, e2.top.getY() );
@@ -27,24 +27,24 @@ class Edge {
         }
     }
 
-    static boolean slopesEqual( Edge e1, Edge e2 ) {
+    static boolean slopesEqual(Edge e1, Edge e2 ) {
         return e1.getDelta().getY() * e2.getDelta().getX() == e1.getDelta().getX() * e2.getDelta().getY();
 
     }
 
-    static void swapPolyIndexes( Edge edge1, Edge edge2 ) {
+    static void swapPolyIndexes(Edge edge1, Edge edge2 ) {
         final int outIdx = edge1.outIdx;
         edge1.outIdx = edge2.outIdx;
         edge2.outIdx = outIdx;
     }
 
-    static void swapSides( Edge edge1, Edge edge2 ) {
+    static void swapSides(Edge edge1, Edge edge2 ) {
         final Edge.Side side = edge1.side;
         edge1.side = edge2.side;
         edge2.side = side;
     }
 
-    static long topX( Edge edge, long currentY ) {
+    static long topX(Edge edge, long currentY ) {
         if (currentY == edge.getTop().getY()) {
             return edge.getTop().getX();
         }
@@ -152,7 +152,7 @@ class Edge {
         return result;
     }
 
-    public Edge getNextInAEL( Direction direction ) {
+    public Edge getNextInAEL(Direction direction ) {
         return direction == Direction.LEFT_TO_RIGHT ? nextInAEL : prevInAEL;
     }
 
@@ -160,7 +160,7 @@ class Edge {
         return top;
     }
 
-    public boolean isContributing( PolyFillType clipFillType, PolyFillType subjFillType, ClipType clipType ) {
+    public boolean isContributing(PolyFillType clipFillType, PolyFillType subjFillType, ClipType clipType ) {
         LOGGER.entering( Edge.class.getName(), "isContributing" );
 
         PolyFillType pft, pft2;
@@ -260,7 +260,7 @@ class Edge {
         return true;
     }
 
-    public boolean isEvenOddAltFillType( PolyFillType clipFillType, PolyFillType subjFillType ) {
+    public boolean isEvenOddAltFillType(PolyFillType clipFillType, PolyFillType subjFillType ) {
         if (polyTyp == PolyType.SUBJECT) {
             return clipFillType == PolyFillType.EVEN_ODD;
         }
@@ -269,7 +269,7 @@ class Edge {
         }
     }
 
-    public boolean isEvenOddFillType( PolyFillType clipFillType, PolyFillType subjFillType ) {
+    public boolean isEvenOddFillType(PolyFillType clipFillType, PolyFillType subjFillType ) {
         if (polyTyp == PolyType.SUBJECT) {
             return subjFillType == PolyFillType.EVEN_ODD;
         }
@@ -336,4 +336,4 @@ class Edge {
         }
     }
 
-};
+}

--- a/Clipper/src/de/lighti/clipper/Edge.java
+++ b/Clipper/src/de/lighti/clipper/Edge.java
@@ -48,7 +48,7 @@ class Edge {
         if (currentY == edge.getTop().getY()) {
             return edge.getTop().getX();
         }
-        return (int) (edge.getBot().getX() + Math.round( edge.deltaX * (currentY - edge.getBot().getY()) ));
+        return edge.getBot().getX() + Math.round( edge.deltaX * (currentY - edge.getBot().getY()) );
     }
 
     private final LongPoint bot;

--- a/Clipper/src/de/lighti/clipper/Path.java
+++ b/Clipper/src/de/lighti/clipper/Path.java
@@ -1,9 +1,9 @@
 package de.lighti.clipper;
 
+import de.lighti.clipper.Point.LongPoint;
+
 import java.util.ArrayList;
 import java.util.Collections;
-
-import de.lighti.clipper.Point.LongPoint;
 
 /**
  * A pure convenience class to avoid writing List<IntPoint> everywhere.
@@ -64,7 +64,7 @@ public class Path extends ArrayList<LongPoint> {
             }
         }
 
-        private static boolean isFirstBottomPt( Path.OutPt btmPt1, Path.OutPt btmPt2 ) {
+        private static boolean isFirstBottomPt(Path.OutPt btmPt1, Path.OutPt btmPt2 ) {
             Path.OutPt p = btmPt1.prev;
             while (p.getPt().equals( btmPt1.getPt() ) && !p.equals( btmPt1 )) {
                 p = p.prev;
@@ -86,7 +86,7 @@ public class Path extends ArrayList<LongPoint> {
                 p = p.next;
             }
             final double dx2n = Math.abs( LongPoint.getDeltaX( btmPt2.getPt(), p.getPt() ) );
-            
+
             if (Math.max( dx1p, dx1n ) == Math.max( dx2p, dx2n ) && Math.min( dx1p, dx1n ) == Math.min( dx2p, dx2n )) {
                 return btmPt1.area() > 0; //if otherwise identical use orientation
             }
@@ -101,7 +101,7 @@ public class Path extends ArrayList<LongPoint> {
 
         OutPt prev;
 
-        public Path.OutPt duplicate( boolean InsertAfter ) {
+        public Path.OutPt duplicate(boolean InsertAfter ) {
             final Path.OutPt result = new Path.OutPt();
             result.setPt( new LongPoint( getPt() ) );
             result.idx = idx;
@@ -190,7 +190,7 @@ public class Path extends ArrayList<LongPoint> {
         public void setPt( LongPoint pt ) {
             this.pt = pt;
         }
-    
+
         private double area() {
             Path.OutPt op = this;
             double a = 0;
@@ -198,7 +198,7 @@ public class Path extends ArrayList<LongPoint> {
                 a = a + (double) (op.prev.getPt().getX() + op.getPt().getX()) * (double) (op.prev.getPt().getY() - op.getPt().getY());
                 op = op.next;
             } while (op != this);
-            return a * 0.5;	
+            return a * 0.5;
         }
     }
 
@@ -249,7 +249,7 @@ public class Path extends ArrayList<LongPoint> {
         }
     }
 
-    private static Path.OutPt excludeOp( Path.OutPt op ) {
+    private static Path.OutPt excludeOp(Path.OutPt op ) {
         final Path.OutPt result = op.prev;
         result.next = op.next;
         op.next.prev = result;
@@ -288,7 +288,7 @@ public class Path extends ArrayList<LongPoint> {
         return cleanPolygon( 1.415 );
     }
 
-    public Path cleanPolygon( double distance ) {
+    public Path cleanPolygon(double distance ) {
         //distance = proximity in units/pixels below which vertices will be stripped.
         //Default ~= sqrt(2) so when adjacent vertices or semi-adjacent vertices have
         //both x & y coords within 1 unit, then the second vertex will be stripped.
@@ -404,7 +404,7 @@ public class Path extends ArrayList<LongPoint> {
         Collections.reverse( this );
     }
 
-    public Path TranslatePath( LongPoint delta ) {
+    public Path TranslatePath(LongPoint delta ) {
         final Path outPath = new Path( size() );
         for (int i = 0; i < size(); i++) {
             outPath.add( new LongPoint( get( i ).getX() + delta.getX(), get( i ).getY() + delta.getY() ) );

--- a/Clipper/src/de/lighti/clipper/Paths.java
+++ b/Clipper/src/de/lighti/clipper/Paths.java
@@ -10,14 +10,14 @@ import java.util.ArrayList;
  */
 public class Paths extends ArrayList<Path> {
 
-    public static Paths closedPathsFromPolyTree( PolyTree polytree ) {
+    public static Paths closedPathsFromPolyTree(PolyTree polytree ) {
         final Paths result = new Paths();
         //        result.Capacity = polytree.Total;
         result.addPolyNode( polytree, PolyNode.NodeType.CLOSED );
         return result;
     }
 
-    public static Paths makePolyTreeToPaths( PolyTree polytree ) {
+    public static Paths makePolyTreeToPaths(PolyTree polytree ) {
 
         final Paths result = new Paths();
         //        result.Capacity = polytree.Total;
@@ -25,7 +25,7 @@ public class Paths extends ArrayList<Path> {
         return result;
     }
 
-    public static Paths openPathsFromPolyTree( PolyTree polytree ) {
+    public static Paths openPathsFromPolyTree(PolyTree polytree ) {
         final Paths result = new Paths();
         //        result.Capacity = polytree.ChildCount;
         for (final PolyNode c : polytree.getChilds()) {
@@ -49,7 +49,7 @@ public class Paths extends ArrayList<Path> {
         super( initialCapacity );
     }
 
-    public void addPolyNode( PolyNode polynode, PolyNode.NodeType nt ) {
+    public void addPolyNode(PolyNode polynode, PolyNode.NodeType nt ) {
         boolean match = true;
         switch (nt) {
             case OPEN:
@@ -73,7 +73,7 @@ public class Paths extends ArrayList<Path> {
         return cleanPolygons( 1.415 );
     }
 
-    public Paths cleanPolygons( double distance ) {
+    public Paths cleanPolygons(double distance ) {
         final Paths result = new Paths( size() );
         for (int i = 0; i < size(); i++) {
             result.add( get( i ).cleanPolygon( distance ) );

--- a/Clipper/src/de/lighti/clipper/Point.java
+++ b/Clipper/src/de/lighti/clipper/Point.java
@@ -34,7 +34,7 @@ public abstract class Point<T extends Number & Comparable<T>> {
     }
 
     public static class LongPoint extends Point<Long> {
-        public static double getDeltaX( LongPoint pt1, LongPoint pt2 ) {
+        public static double getDeltaX(LongPoint pt1, LongPoint pt2 ) {
             if (pt1.getY() == pt2.getY()) {
                 return Edge.HORIZONTAL;
             }
@@ -80,18 +80,18 @@ public abstract class Point<T extends Number & Comparable<T>> {
         }
     }
 
-    static boolean arePointsClose( Point<? extends Number> pt1, Point<? extends Number> pt2, double distSqrd ) {
+    static boolean arePointsClose(Point<? extends Number> pt1, Point<? extends Number> pt2, double distSqrd ) {
         final double dx = pt1.x.doubleValue() - pt2.x.doubleValue();
         final double dy = pt1.y.doubleValue() - pt2.y.doubleValue();
         return dx * dx + dy * dy <= distSqrd;
     }
 
-    static double distanceFromLineSqrd( Point<? extends Number> pt, Point<? extends Number> ln1, Point<? extends Number> ln2 ) {
+    static double distanceFromLineSqrd(Point<? extends Number> pt, Point<? extends Number> ln1, Point<? extends Number> ln2 ) {
         //The equation of a line in general form (Ax + By + C = 0)
-        //given 2 points (x¹,y¹) & (x²,y²) is ...
-        //(y¹ - y²)x + (x² - x¹)y + (y² - y¹)x¹ - (x² - x¹)y¹ = 0
-        //A = (y¹ - y²); B = (x² - x¹); C = (y² - y¹)x¹ - (x² - x¹)y¹
-        //perpendicular distance of point (x³,y³) = (Ax³ + By³ + C)/Sqrt(A² + B²)
+        //given 2 points (xï¿½,yï¿½) & (xï¿½,yï¿½) is ...
+        //(yï¿½ - yï¿½)x + (xï¿½ - xï¿½)y + (yï¿½ - yï¿½)xï¿½ - (xï¿½ - xï¿½)yï¿½ = 0
+        //A = (yï¿½ - yï¿½); B = (xï¿½ - xï¿½); C = (yï¿½ - yï¿½)xï¿½ - (xï¿½ - xï¿½)yï¿½
+        //perpendicular distance of point (xï¿½,yï¿½) = (Axï¿½ + Byï¿½ + C)/Sqrt(Aï¿½ + Bï¿½)
         //see http://en.wikipedia.org/wiki/Perpendicular_distance
         final double A = ln1.y.doubleValue() - ln2.y.doubleValue();
         final double B = ln2.x.doubleValue() - ln1.x.doubleValue();

--- a/Clipper/src/de/lighti/clipper/Point.java
+++ b/Clipper/src/de/lighti/clipper/Point.java
@@ -88,10 +88,10 @@ public abstract class Point<T extends Number & Comparable<T>> {
 
     static double distanceFromLineSqrd(Point<? extends Number> pt, Point<? extends Number> ln1, Point<? extends Number> ln2 ) {
         //The equation of a line in general form (Ax + By + C = 0)
-        //given 2 points (x�,y�) & (x�,y�) is ...
-        //(y� - y�)x + (x� - x�)y + (y� - y�)x� - (x� - x�)y� = 0
-        //A = (y� - y�); B = (x� - x�); C = (y� - y�)x� - (x� - x�)y�
-        //perpendicular distance of point (x�,y�) = (Ax� + By� + C)/Sqrt(A� + B�)
+        //given 2 points (x¹,y¹) & (x²,y²) is ...
+        //(y¹ - y²)x + (x² - x¹)y + (y² - y¹)x¹ - (x² - x¹)y¹ = 0
+        //A = (y¹ - y²); B = (x² - x¹); C = (y² - y¹)x¹ - (x² - x¹)y¹
+        //perpendicular distance of point (x³,y³) = (Ax³ + By³ + C)/Sqrt(A² + B²)
         //see http://en.wikipedia.org/wiki/Perpendicular_distance
         final double A = ln1.y.doubleValue() - ln2.y.doubleValue();
         final double B = ln2.x.doubleValue() - ln1.x.doubleValue();

--- a/Clipper/src/de/lighti/clipper/PolyNode.java
+++ b/Clipper/src/de/lighti/clipper/PolyNode.java
@@ -8,7 +8,7 @@ import de.lighti.clipper.Clipper.EndType;
 import de.lighti.clipper.Clipper.JoinType;
 import de.lighti.clipper.Point.LongPoint;
 
-class PolyNode {
+public class PolyNode {
     enum NodeType {
         ANY, OPEN, CLOSED
     }

--- a/Clipper/src/de/lighti/clipper/PolyNode.java
+++ b/Clipper/src/de/lighti/clipper/PolyNode.java
@@ -1,12 +1,12 @@
 package de.lighti.clipper;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import de.lighti.clipper.Clipper.EndType;
 import de.lighti.clipper.Clipper.JoinType;
 import de.lighti.clipper.Point.LongPoint;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 class PolyNode {
     enum NodeType {
@@ -18,7 +18,7 @@ class PolyNode {
     private int index;
     private JoinType joinType;
     private EndType endType;
-    protected final List<PolyNode> childs = new ArrayList<PolyNode>();
+    final List<PolyNode> childs = new ArrayList<>();
     private boolean isOpen;
 
     public void addChild( PolyNode child ) {

--- a/Clipper/src/de/lighti/clipper/PolyTree.java
+++ b/Clipper/src/de/lighti/clipper/PolyTree.java
@@ -3,7 +3,7 @@ package de.lighti.clipper;
 import java.util.ArrayList;
 import java.util.List;
 
-class PolyTree extends PolyNode {
+public class PolyTree extends PolyNode {
     private final List<PolyNode> allPolys = new ArrayList<PolyNode>();
 
     public void Clear() {


### PR DESCRIPTION
This is a series of small cleanups mostly around these topics:
- remove un-necessary visibility modifiers for interfaces
- remove type for generics when automatically inferred
- remove extra empty spaces for methods
- remove semicolons when un-necessary