### PR TITLE
Fix clerical error in DefaultClipper

### DIFF
--- a/Clipper/src/de/lighti/clipper/DefaultClipper.java
+++ b/Clipper/src/de/lighti/clipper/DefaultClipper.java
@@ -1216,7 +1216,7 @@ public class DefaultClipper extends ClipperBase {
                     continue;
                 }
                 else if (outRec.isOpen) {
-                    fixupOutPolygon( outRec );
+                    fixupOutPolyline( outRec );
                 }
                 else {
                     fixupOutPolygon( outRec );


### PR DESCRIPTION
I noticed that this java port behaved different than the C# version for my usecase.

When comparing the C# sources to this, I noticed that there seems to be a mistake in `executeInternal` of DefaultClipper. By changing this line everything worked as expected again.