### PR TITLE
Fix open polyline clipping

### DIFF
--- a/Clipper/src/de/lighti/clipper/DefaultClipper.java
+++ b/Clipper/src/de/lighti/clipper/DefaultClipper.java
@@ -1216,7 +1216,7 @@ public class DefaultClipper extends ClipperBase {
                     continue;
                 }
                 else if (outRec.isOpen) {
-                    fixupOutPolygon( outRec );
+                    fixupOutPolyline( outRec );
                 }
                 else {
                     fixupOutPolygon( outRec );


### PR DESCRIPTION
Fixed to match original C# code (lines 1561-), fixes clipping of open polylines:
```
          foreach (OutRec outRec in m_PolyOuts)
          {
            if (outRec.Pts == null) 
                continue;
            else if (outRec.IsOpen)
                FixupOutPolyline(outRec);
            else
                FixupOutPolygon(outRec);
          }
```
